### PR TITLE
Make camera exceptions percolate

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-FlashBulbMob-Android
+flashbulbmob-android

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="" />
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,10 +3,16 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.10" />
         <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+        <option name="myModules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/FlashBulbMob-Android.iml" filepath="$PROJECT_DIR$/FlashBulbMob-Android.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/flashbulbmob-android.iml" filepath="$PROJECT_DIR$/flashbulbmob-android.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/constantbeta/com/flashbulbmob/FlashTogglerNew.java
+++ b/app/src/main/java/constantbeta/com/flashbulbmob/FlashTogglerNew.java
@@ -1,6 +1,7 @@
 package constantbeta.com.flashbulbmob;
 
 import android.content.Context;
+import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 import android.os.Build;
@@ -13,7 +14,7 @@ public class FlashTogglerNew implements FlashToggler {
     private final String cameraId;
     private boolean isFlashOn;
 
-    public FlashTogglerNew(Context context) throws Exception {
+    public FlashTogglerNew(Context context) throws CameraAccessException {
         manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
         cameraId = findCamera();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -76,12 +77,15 @@ public class FlashTogglerNew implements FlashToggler {
         }
     }
 
-    private String findCamera() throws Exception {
+    // Looks for any camera with an associated flash device. Returns 1st one found or null if none
+    private String findCamera() throws CameraAccessException {
         for (final String cameraId : manager.getCameraIdList()) {
             if (manager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.FLASH_INFO_AVAILABLE)) {
                 return cameraId;
             }
         }
-        throw new Exception("Could not find a camera that has a flash");
+
+        return null;    // No camera with flash found
+
     }
 }

--- a/app/src/main/java/constantbeta/com/flashbulbmob/ServiceNotSupportedException.java
+++ b/app/src/main/java/constantbeta/com/flashbulbmob/ServiceNotSupportedException.java
@@ -1,0 +1,7 @@
+package constantbeta.com.flashbulbmob;
+
+/**
+ * Created by josh on 4/8/2016.
+ */
+public class ServiceNotSupportedException extends Exception {
+}

--- a/app/src/main/java/constantbeta/com/flashbulbmob/TorchRepeaterActivity.java
+++ b/app/src/main/java/constantbeta/com/flashbulbmob/TorchRepeaterActivity.java
@@ -53,14 +53,12 @@ public class TorchRepeaterActivity extends AppCompatActivity
     protected void onStart()
     {
         super.onStart();
-        setupFlashToggler();
     }
 
     @Override
     protected void onStop()
     {
         super.onStop();
-        releaseFlashToggler();
     }
 
     private void setupToolbar()
@@ -96,16 +94,8 @@ public class TorchRepeaterActivity extends AppCompatActivity
         disableAndHide(stopButton);
     }
 
-    private void setupFlashToggler()
-    {
-        try
-        {
-            flashToggler = new FlashTogglerDeprecated(getApplicationContext());
-        }
-        catch (final Exception e)
-        {
-            // no-op
-        }
+    private void setupFlashToggler() throws Exception {
+           flashToggler = new FlashTogglerDeprecated(getApplicationContext());
     }
 
     private void releaseFlashToggler()
@@ -172,12 +162,12 @@ public class TorchRepeaterActivity extends AppCompatActivity
         offMillisEditText.setEnabled(true);
     }
 
-    public void startPressed(View view)
-    {
+    public void startPressed(View view) throws Exception {
         dismissKeyboard();
         disableAndHide(canStartButton);
         enableAndShow(stopButton);
         disableInputs();
+        setupFlashToggler();
         torchRepeater = new TorchRepeater(flashToggler, onMillis(), offMillis());
         torchRepeater.start();
     }
@@ -186,6 +176,8 @@ public class TorchRepeaterActivity extends AppCompatActivity
     {
         torchRepeater.stop();
         torchRepeater = null;
+        releaseFlashToggler();
+        
         enableInputs();
         disableAndHide(stopButton);
         enableAndShow(canStartButton);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Fri Apr 08 09:34:53 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Changes to move flashtoggler constructor into main thread by doing it in
start button. This lets exceptions percolate and become visible rather
than getting consumed in an empty try/catch.

Also moved to Android Studio 2.
